### PR TITLE
Issues with text synchronization (textDocument/didChange event) + mapping IJ logical column position to LSP position

### DIFF
--- a/intellij-lsp/src/com/github/gtache/lsp/contributors/LSPCompletionContributor.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/contributors/LSPCompletionContributor.scala
@@ -15,7 +15,7 @@ class LSPCompletionContributor extends CompletionContributor {
     import scala.collection.JavaConverters._
     val editor = parameters.getEditor
     val offset = parameters.getOffset
-    val serverPos = DocumentUtils.logicalToLSPPos(editor.offsetToLogicalPosition(offset))
+    val serverPos = DocumentUtils.offsetToLSPPos(editor, offset)
     val toAdd = EditorEventManager.forEditor(editor).map(e => e.completion(serverPos)).getOrElse(Iterable()).asJava
 
     result.addAllElements(toAdd)

--- a/intellij-lsp/src/com/github/gtache/lsp/editor/EditorEventManager.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/editor/EditorEventManager.scala
@@ -30,6 +30,7 @@ import com.intellij.openapi.fileEditor.{FileDocumentManager, FileEditorManager, 
 import com.intellij.openapi.fileTypes.PlainTextLanguage
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.{LocalFileSystem, VirtualFile}
 import com.intellij.psi.{PsiDocumentManager, PsiElement}
 import com.intellij.ui.Hint
@@ -467,7 +468,6 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
     * @param event The DocumentEvent
     */
   def documentChanged(event: DocumentEvent): Unit = {
-    pool(() =>
       if (!editor.isDisposed) {
         if (event.getDocument == editor.getDocument) {
           predTime = System.nanoTime() //So that there are no hover events while typing
@@ -481,10 +481,23 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
               val changeEvent = changesParams.getContentChanges.get(0)
               val newText = event.getNewFragment
               val offset = event.getOffset
-              val length = event.getNewLength
-              val range = new Range(DocumentUtils.offsetToLSPPos(editor, offset), DocumentUtils.offsetToLSPPos(editor, offset + length))
+              val newTextLength = event.getNewLength
+              val lspPosition: Position = DocumentUtils.offsetToLSPPos(editor, offset)
+              val startLine = lspPosition.getLine
+              val startColumn = lspPosition.getCharacter
+              val oldText = event.getOldFragment
+
+              //if text was deleted/replaced, calculate the end position of inserted/deleted text
+              val (endLine, endColumn) = if (oldText.length() > 0) {
+                val line = startLine + StringUtil.countNewLines(oldText)
+                val oldLines = oldText.toString.split('\n')
+                val oldTextLength = if (oldLines.isEmpty) 0 else oldLines.last.length
+                val column = if (oldLines.length == 1) startColumn + oldTextLength else oldTextLength
+                (line, column)
+              } else (startLine, startColumn) //if insert or no text change, the end position is the same
+            val range = new Range(new Position(startLine, startColumn), new Position(endLine, endColumn))
               changeEvent.setRange(range)
-              changeEvent.setRangeLength(length)
+              changeEvent.setRangeLength(newTextLength)
               changeEvent.setText(newText.toString)
 
             case TextDocumentSyncKind.Full =>
@@ -494,7 +507,7 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
         } else {
           LOG.error("Wrong document for the EditorEventManager")
         }
-      })
+      }
   }
 
   /**

--- a/intellij-lsp/src/com/github/gtache/lsp/utils/DocumentUtils.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/utils/DocumentUtils.scala
@@ -3,6 +3,8 @@ package com.github.gtache.lsp.utils
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.{Editor, LogicalPosition}
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.DocumentUtil
 import org.eclipse.lsp4j.Position
 
 /**
@@ -39,17 +41,23 @@ object DocumentUtils {
     * @return an LSP position
     */
   def offsetToLSPPos(editor: Editor, offset: Int): Position = {
-    logicalToLSPPos(editor.offsetToLogicalPosition(offset))
+    val doc = editor.getDocument
+    val line = doc.getLineNumber(offset)
+    val lineStart = doc.getLineStartOffset(line)
+    val lineTextBeforeOffset = doc.getText(TextRange.create(lineStart, offset))
+    val column = lineTextBeforeOffset.length
+    new Position(line, column)
   }
 
   /**
     * Transforms a LogicalPosition (IntelliJ) to an LSP Position
     *
     * @param position the LogicalPosition
+    * @param editor   The editor
     * @return the Position
     */
-  def logicalToLSPPos(position: LogicalPosition): Position = {
-    new Position(position.line, position.column)
+  def logicalToLSPPos(position: LogicalPosition, editor: Editor): Position = {
+    offsetToLSPPos(editor, editor.logicalPositionToOffset(position))
   }
 
   /**
@@ -60,21 +68,18 @@ object DocumentUtils {
     * @return The offset
     */
   def LSPPosToOffset(editor: Editor, pos: Position): Int = {
-    val offset = editor.logicalPositionToOffset(LSPToLogicalPos(pos))
-    val docLength = editor.getDocument.getTextLength
+    val line = pos.getLine
+    val doc = editor.getDocument
+    val lineTextForPosition = doc.getText(DocumentUtil.getLineTextRange(doc, line)).substring(0, pos.getCharacter)
+    val tabs = StringUtil.countChars(lineTextForPosition, '\t')
+    val tabSize = editor.getSettings.getTabSize(editor.getProject)
+    val column = tabs * tabSize + lineTextForPosition.length - tabs
+    val offset = editor.logicalPositionToOffset(new LogicalPosition(line, column))
+    val docLength = doc.getTextLength
     if (offset > docLength) {
       LOG.warn("Offset greater than text length : " + offset + " > " + docLength)
     }
     math.min(math.max(offset, 0), docLength)
   }
 
-  /**
-    * Transforms an LSP position to a LogicalPosition
-    *
-    * @param position The LSPPos
-    * @return The LogicalPos
-    */
-  def LSPToLogicalPos(position: Position): LogicalPosition = {
-    new LogicalPosition(position.getLine, position.getCharacter)
-  }
 }


### PR DESCRIPTION
[This commit](https://github.com/gtache/intellij-lsp/commit/794dfd00599d35a98f0f31f69afc87dd5a4517f0) fixes issue with  `textDocument/didChange` event. As now it seems that the LSP end position is [not calculated correctly](https://github.com/PowerShell/PowerShellEditorServices/issues/589#issuecomment-354855942). The end position should be calculated based on old (deleted/replaced) text.

[This commit](https://github.com/gtache/intellij-lsp/commit/b8627ce08e7644e7a33f69fe63cb99742a5a8480) maps IJ document logical position to correct LSP position (one should [take tab length into an account](https://github.com/PowerShell/PowerShellEditorServices/issues/589#issuecomment-355022553)).

At least these changes helped me to resolve my issues.

Overall the plugin does great job!