### PR TITLE
Fix bug with Code completion not showing when using textedit

### DIFF
--- a/intellij-lsp/build.gradle
+++ b/intellij-lsp/build.gradle
@@ -14,6 +14,10 @@ intellij {
     pluginName 'LSP Support'
 }
 
+patchPluginXml {
+    untilBuild '2018.3'
+}
+
 dependencies {
     compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j', version: '0.6.0'
     compile group: 'io.get-coursier', name: 'coursier_2.12', version: '1.0.3'

--- a/intellij-lsp/src/com/github/gtache/lsp/editor/EditorEventManager.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/editor/EditorEventManager.scala
@@ -316,7 +316,7 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
                     })*/
             if (textEdit != null) {
               if (addTextEdits != null) {
-                lookupElementBuilder = LookupElementBuilder.create("")
+                lookupElementBuilder = LookupElementBuilder.create(presentableText, "")
                   .withInsertHandler((context: InsertionContext, item: LookupElement) => {
                     context.commitDocument()
                     invokeLater(() => {
@@ -324,18 +324,21 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
                       if (command != null) executeCommands(Iterable(command))
                     })
                   })
+                  .withLookupString(presentableText)
               } else {
-                lookupElementBuilder = LookupElementBuilder.create("")
+                lookupElementBuilder = LookupElementBuilder.create(presentableText, "")
                   .withInsertHandler((context: InsertionContext, item: LookupElement) => {
                     context.commitDocument()
                     invokeLater(() => {
                       applyEdit(edits = Seq(textEdit), name = "Completion : " + label)
                       if (command != null) executeCommands(Iterable(command))
+                      editor.getCaretModel.moveCaretRelatively(textEdit.getNewText.length,0,false,false,true)
                     })
                   })
+                  .withLookupString(presentableText)
               }
             } else if (addTextEdits != null) {
-              lookupElementBuilder = LookupElementBuilder.create("")
+              lookupElementBuilder = LookupElementBuilder.create(presentableText, "")
                 .withInsertHandler((context: InsertionContext, item: LookupElement) => {
                   context.commitDocument()
                   invokeLater(() => {
@@ -343,6 +346,7 @@ class EditorEventManager(val editor: Editor, val mouseListener: EditorMouseListe
                     if (command != null) executeCommands(Iterable(command))
                   })
                 })
+                .withLookupString(presentableText)
             } else {
               lookupElementBuilder = LookupElementBuilder.create(if (insertText != null && insertText != "") insertText else label)
               if (command != null) lookupElementBuilder = lookupElementBuilder.withInsertHandler((context: InsertionContext, item: LookupElement) => {


### PR DESCRIPTION
While developing my language server for SpecFlow (https://github.com/techtalk/SpecFlow.IDEExtension) I stumbled on a bug when using textEdits.

The problem is that textEdits use LookupElements without lookupObjects or lookupStrings. Not using objects makes the IDE drop every LookupElement but one as it compares them. Not using any lookupString fails comparison with the entered text if completion is caused by autocompletion and not by CTRL + SPACe.

The fix adds a lookupObject which does not get inserted automatically and a lookupString via the builder method which also does not get inserted automatically. This resolves the two described issues without affecting insert behavior.

Also moves the caret to the end of the insert. 