### PR TITLE
Always create ProblemDescriptor even if codeAction is undefined

### DIFF
--- a/intellij-lsp/src/com/github/gtache/lsp/contributors/inspection/LSPInspection.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/contributors/inspection/LSPInspection.scala
@@ -44,13 +44,13 @@ class LSPInspection extends LocalInspectionTool {
             }
             val element = LSPPsiElement(name, m.editor.getProject, start, end, file)
             val codeActionResult = m.codeAction(element)
-            if (codeActionResult != null) {
-              val (commandsE, codeActionsE) = codeActionResult.filter(e => e != null && (e.isLeft || e.isRight)).partition(e => e.isLeft)
-              val commands = commandsE.map(e => e.getLeft).map(c => new LSPCommandFix(uri, c))
-              val codeActions = codeActionsE.map(e => e.getRight).map(c => new LSPCodeActionFix(uri, c))
-              manager.createProblemDescriptor(element, null.asInstanceOf[TextRange], diagnostic.getMessage, severity, isOnTheFly,
-                (commands ++ codeActions).toArray: _*)
-            } else null
+            val fixes = if (codeActionResult != null) {
+                          val (commandsE, codeActionsE) = codeActionResult.filter(e => e != null && (e.isLeft || e.isRight)).partition(e => e.isLeft)
+                          val commands = commandsE.map(e => e.getLeft).map(c => new LSPCommandFix(uri, c))
+                          val codeActions = codeActionsE.map(e => e.getRight).map(c => new LSPCodeActionFix(uri, c))
+                          (commands ++ codeActions).toArray
+                        } else null
+            manager.createProblemDescriptor(element, null.asInstanceOf[TextRange], diagnostic.getMessage, severity, isOnTheFly, fixes: _*)
           } else null
         }.toArray.filter(d => d != null)
       }


### PR DESCRIPTION
Fixes #51 

First of all, thank you for the awesome plugin. It makes Ruby developer experience on RubyMine extremely comfortable.

I'm working on developing a language server for [Steep](https://github.com/soutaro/steep). At that time, I faced with the same issue as #51.
According to my investigation, it seems that InspectionManager does not create ProblemDescriptor if the server does not support codeAction.
In v1.4.0, regardless of whether codeAction is supported or not, the Manager creates ProblemDescriptor.

https://github.com/gtache/intellij-lsp/blob/54b777e9f9857f3da2d90ac145708c580c7cc1ec/intellij-lsp/src/com/github/gtache/lsp/contributors/inspection/LSPInspection.scala#L45-L48

As with the behavior of v1.4.0, this PR makes the Manager always creates ProblemDescriptor regardless of whether codeAction is supported or not. I confirmed this behavior with IntelliJ IDEA CE 2018.3.

![untitled](https://user-images.githubusercontent.com/9624059/52564877-8f682180-2e48-11e9-8422-0f40960021ad.gif)

Since I'm not familiar with Scala, tests have not been added to this PR. Please tell me if you have a good suggestion. Thanks again!