### PR TITLE
#84 Support for language id and full file name extensions

### DIFF
--- a/intellij-lsp/src/com/github/gtache/lsp/PluginMain.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/PluginMain.scala
@@ -130,10 +130,22 @@ object PluginMain {
         if (forced == null) {
           val forcedDef = forcedAssociations.get((uri, pUri)).orNull
           if (forcedDef == null) {
+            var connected: Boolean = false;
             extToServerDefinition.get(ext).foreach(s => {
               val wrapper = getWrapperFor(ext, editor, s)
               if (wrapper != null) {
                 LOG.info("Adding file " + file.getName)
+                wrapper.connect(editor)
+                connected = true
+              }
+            })
+
+            // if not connected try with full file name, may the extention is a specific file name.
+            val fname = file.getName
+            extToServerDefinition.get(fname).foreach(s => {
+              val wrapper = getWrapperFor(fname, editor, s)
+              if (wrapper != null) {
+                LOG.info("Adding file [Full File Name Mode] " + file.getName)
                 wrapper.connect(editor)
               }
             })

--- a/intellij-lsp/src/com/github/gtache/lsp/client/languageserver/serverdefinition/RawCommandServerDefinition.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/client/languageserver/serverdefinition/RawCommandServerDefinition.scala
@@ -13,7 +13,7 @@ object RawCommandServerDefinition extends UserConfigurableServerDefinitionObject
     if (arr.head == typ) {
       val arrTail = arr.tail
       if (arrTail.length > 1) {
-        RawCommandServerDefinition(arrTail.head, Utils.parseArgs(arrTail.tail))
+        new RawCommandServerDefinition(arrTail.head, Utils.parseArgs(arrTail.tail))
       } else {
         null
       }
@@ -33,9 +33,13 @@ object RawCommandServerDefinition extends UserConfigurableServerDefinitionObject
   * @param ext     The extension
   * @param command The command to run
   */
-case class RawCommandServerDefinition(ext: String, command: Array[String]) extends CommandServerDefinition {
+case class RawCommandServerDefinition(langId: String,  ext: String, command: Array[String]) extends CommandServerDefinition {
 
   import RawCommandServerDefinition.typ
+
+  def this(ext: String, command: Array[String]) =  this(ext, ext, command)
+
+  override def id: String = langId
 
   /**
     * @return The array corresponding to the server definition
@@ -45,7 +49,7 @@ case class RawCommandServerDefinition(ext: String, command: Array[String]) exten
   override def toString: String = typ + " : " + command.mkString(" ")
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case RawCommandServerDefinition(ext1, commands1) =>
+    case RawCommandServerDefinition(langId1, ext1, commands1) =>
       ext == ext1 && command.toSeq == commands1.toSeq
     case _ => false
   }


### PR DESCRIPTION
Some of the language server implementation extension and language id are
different. So then the specific language id must be provided. Now the
RawCommandServerDefinition.scala support excepting language id as well.

Some of the language server implementation are based on cetain file
names than the extension. Now as a fallback option if the extension
(which is more prominent approach) is not found the LSP will look for
file name mapping as well.

Signed-off-by: gayanper <gayanper@gmail.com>