### PR TITLE
Fixed crash when clicking gutter to show git changes on a line

### DIFF
--- a/intellij-lsp/src/com/github/gtache/lsp/client/languageserver/wrapper/LanguageServerWrapperImpl.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/client/languageserver/wrapper/LanguageServerWrapperImpl.scala
@@ -47,7 +47,11 @@ object LanguageServerWrapperImpl {
     * @return The wrapper for the given editor, or None
     */
   def forEditor(editor: Editor): Option[LanguageServerWrapper] = {
-    uriToLanguageServerWrapper.get((FileUtils.editorToURIString(editor), FileUtils.editorToProjectFolderUri(editor)))
+    if (editor.getProject == null){
+      None
+    } else {
+      uriToLanguageServerWrapper.get((FileUtils.editorToURIString(editor), FileUtils.editorToProjectFolderUri(editor)))
+    }
   }
 }
 


### PR DESCRIPTION
Clicking on the gutter to show uncommitted changes in git should open a small popover window. Doing this was causing an exception:

```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.intellij.openapi.project.ProjectUtil.guessProjectDir, parameter $this$guessProjectDir
	at com.intellij.openapi.project.ProjectUtil.guessProjectDir(ProjectUtil.kt)
	at com.github.gtache.lsp.utils.FileUtils$.editorToProjectFolderPath(FileUtils.scala:153)
	at com.github.gtache.lsp.utils.FileUtils$.editorToProjectFolderUri(FileUtils.scala:149)
	at com.github.gtache.lsp.client.languageserver.wrapper.LanguageServerWrapperImpl$.forEditor(LanguageServerWrapperImpl.scala:50)
	at com.github.gtache.lsp.PluginMain$.editorClosed(PluginMain.scala:275)
	at com.github.gtache.lsp.editor.listeners.EditorListener.editorReleased(EditorListener.scala:15)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.intellij.util.EventDispatcher.dispatchVoidMethod(EventDispatcher.java:130)
	at com.intellij.util.EventDispatcher.access$000(EventDispatcher.java:24)
```

When it should have shown:

<img width="395" alt="Screen Shot 2019-09-17 at 2 57 21 AM" src="https://user-images.githubusercontent.com/251087/65022813-3f2dd200-d8f7-11e9-9bbc-6df92fbbd29d.png">

Thanks again for this awesome plugin :)