### PR TITLE
Fix icon provide extension name

### DIFF
--- a/intellij-lsp/src/com/github/gtache/lsp/contributors/icon/LSPIconProvider.scala
+++ b/intellij-lsp/src/com/github/gtache/lsp/contributors/icon/LSPIconProvider.scala
@@ -7,7 +7,7 @@ import javax.swing.Icon
 import org.eclipse.lsp4j.{CompletionItemKind, SymbolKind}
 
 object LSPIconProvider {
-  val EP_NAME: ExtensionPointName[LSPIconProvider] = ExtensionPointName.create("com.github.gtache.lsp.contributors.icon.LSPIconProvider")
+  val EP_NAME: ExtensionPointName[LSPIconProvider] = ExtensionPointName.create("com.github.gtache.lsp.lspIconProvider")
 
   def getDefaultCompletionIcon(kind: CompletionItemKind): Icon = LSPDefaultIconProvider.getCompletionIcon(kind)
 


### PR DESCRIPTION
Reason is that extension name is different from the base implementation class

Fixes #115

Signed-off-by: Jeff MAURY <jmaury@redhat.com>